### PR TITLE
Fix ZoomOutCamera not loading in latest game version

### DIFF
--- a/ZoomOutCamera/CameraSystemPatch.cs
+++ b/ZoomOutCamera/CameraSystemPatch.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using Timberborn.CameraSystem;
+using Timberborn.Common;
 using UnityEngine;
 
 namespace ZoomOutCamera
@@ -9,16 +10,16 @@ namespace ZoomOutCamera
         [HarmonyPatch(typeof(CameraComponent), "Awake")]
         public static class UpdateZoomLimit
         {
-            private static void Postfix(CameraComponent __instance)
+            private static void Postfix(ref FloatLimits ____defaultZoomLimits, ref FloatLimits ____relaxedZoomLimits, FloatLimits ____mapEditorZoomLimits)
             {
-                var default_initial = __instance.DefaultZoomLimits;
-                var relaxed_initial = __instance.RelaxedZoomLimits;
-                __instance.DefaultZoomLimits = __instance.RelaxedZoomLimits;
-                __instance.RelaxedZoomLimits = __instance.MapEditorZoomLimits;
+                var default_initial = ____defaultZoomLimits;
+                var relaxed_initial = ____relaxedZoomLimits;
+                ____defaultZoomLimits = ____relaxedZoomLimits;
+                ____relaxedZoomLimits = ____mapEditorZoomLimits;
                 Debug.Log("Increased zoom limits.");
-                Debug.Log($"Default Zoom Limit {default_initial.Max} -> {__instance.DefaultZoomLimits.Max}");
-                Debug.Log($"Relaxed Zoom Limit {relaxed_initial.Max} -> {__instance.MapEditorZoomLimits.Max}");
-                Debug.Log($"Map Editor Zoom Limit {__instance.MapEditorZoomLimits.Max}, Unchanged");
+                Debug.Log($"Default Zoom Limit {default_initial.Max} -> {____defaultZoomLimits.Max}");
+                Debug.Log($"Relaxed Zoom Limit {relaxed_initial.Max} -> {____mapEditorZoomLimits.Max}");
+                Debug.Log($"Map Editor Zoom Limit {____mapEditorZoomLimits.Max}, Unchanged");
             }
         }
     }

--- a/ZoomOutCamera/Registrar.cs
+++ b/ZoomOutCamera/Registrar.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace ZoomOutCamera
 {
-    [BepInPlugin("Matt.McMullan.Timberborn.ZoomOutCamera", "Zoom Out The Camera", "1.0.0.0")]
+    [BepInPlugin("Matt.McMullan.Timberborn.ZoomOutCamera", "Zoom Out The Camera", "1.0.1.0")]
     [BepInProcess("Timberborn.exe")]
     public class Registrar : BaseUnityPlugin
     {

--- a/ZoomOutCamera/thunderstore/manifest.json
+++ b/ZoomOutCamera/thunderstore/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "ZoomOutCamera",
-    "version_number": "1.0.0",
+    "version_number": "1.0.1",
     "website_url": "https://github.com/MattMcMullan/Timberborn-Mods",
     "description": "Allows the default camera to zoom out to the relaxed camera distance. Allows the relaxed camera to zoom out to the map editor camera distance.",
     "dependencies": ["BepInEx-BepInExPack_Timberborn-5.4.15"]


### PR DESCRIPTION
The field names got changed and so their visibility. Updated the names and am injecting them into the method using Harmony - as one can no longer access them via instance.

Incremented fix-version by one to 1.0.1.